### PR TITLE
Provisioning changes for syslog-port in vizd

### DIFF
--- a/contrail_setup_utils/setup.py
+++ b/contrail_setup_utils/setup.py
@@ -239,6 +239,7 @@ class Setup(object):
         parser.add_argument("--redis_role", help = "Redis Role of Node")
         parser.add_argument("--self_collector_ip", help = "Self IP of Collector Node")
         parser.add_argument("--analytics_data_ttl", help = "TTL in hours of analytics data stored in database", type = int, default = 24 * 2)
+        parser.add_argument("--analytics_syslog_port", help = "Listen port for analytics syslog server", type = int, default = -1)
         parser.add_argument("--storage-master", help = "IP Address of storage master node")
         parser.add_argument("--storage-hostnames", help = "Host names of storage nodes", nargs='+', type=str)
         parser.add_argument("--storage-hosts", help = "IP Addresses of storage nodes", nargs='+', type=str)
@@ -732,7 +733,8 @@ HWADDR=%s
                              '__contrail_listen_port__' : '8086',
                              '__contrail_http_server_port__' : '8089',
                              '__contrail_cassandra_server_list__' : ' '.join('%s:%s' % cassandra_server for cassandra_server in cassandra_server_list),
-                             '__contrail_analytics_data_ttl__' : self._args.analytics_data_ttl}
+                             '__contrail_analytics_data_ttl__' : self._args.analytics_data_ttl,
+                             '__contrail_analytics_syslog_port__' : '--syslog-port ' + str(self._args.analytics_syslog_port)}
             self._template_substitute_write(vizd_param_template.template,
                                            template_vals, temp_dir_name + '/vizd_param')
             local("sudo mv %s/vizd_param /etc/contrail/vizd_param" %(temp_dir_name))

--- a/setup-vnc-collector.py
+++ b/setup-vnc-collector.py
@@ -37,6 +37,9 @@ class SetupVncCollector(object):
         if self._args.analytics_data_ttl is not None:
             setup_args_str = setup_args_str + " --analytics_data_ttl %d" \
                                  % (self._args.analytics_data_ttl)                                                   
+        if self._args.analytics_syslog_port is not None:
+            setup_args_str = setup_args_str + " --analytics_syslog_port %d" \
+                                 % (self._args.analytics_syslog_port)                                                   
 
         setup_obj = Setup(setup_args_str)
         setup_obj.do_setup()
@@ -47,7 +50,7 @@ class SetupVncCollector(object):
         '''
         Eg. python setup-vnc-collector.py --cassandra_ip_list 10.1.1.1 10.1.1.2 
             --cfgm_ip 10.1.5.11 --self_collector_ip 10.1.5.11 
-            --analytics_data_ttl 1
+            --analytics_data_ttl 1 --analytics_syslog_port 3514
         '''
 
         # Source any specified config/ini file
@@ -87,6 +90,7 @@ class SetupVncCollector(object):
         parser.add_argument("--self_collector_ip", help = "IP Address of the collector node")
         parser.add_argument("--num_nodes", help = "Number of collector nodes", type = int)
         parser.add_argument("--analytics_data_ttl", help = "TTL in hours of data stored in cassandra database", type = int)
+        parser.add_argument("--analytics_syslog_port", help = "Listen port for analytics syslog server", type = int)
         self._args = parser.parse_args(remaining_argv)
 
     #end _parse_args

--- a/templates/vizd_param_template.py
+++ b/templates/vizd_param_template.py
@@ -11,4 +11,5 @@ HTTP_SERVER_PORT=$__contrail_http_server_port__
 LOG_FILE=$__contrail_log_file__
 LOG_LOCAL=$__contrail_log_local__
 ANALYTICS_DATA_TTL=$__contrail_analytics_data_ttl__
+ANALYTICS_SYSLOG_PORT=$__contrail_analytics_syslog_port__
 """)


### PR DESCRIPTION
Add support to configure syslog-port in vizd via addition of option
collector_syslog_port in fabric and associated changes in provisioning
scripts
