### PR TITLE
Configuration format changes for some of the contrail software daemons

### DIFF
--- a/contrail_setup_utils/setup.py
+++ b/contrail_setup_utils/setup.py
@@ -847,30 +847,21 @@ HWADDR=%s
         if 'collector' in self._args.role:
             self_collector_ip = self._args.self_collector_ip
             cassandra_server_list = [(cassandra_server_ip, '9160') for cassandra_server_ip in self._args.cassandra_ip_list]
-            template_vals = {'__contrail_log_file__' : '/var/log/contrail/collector.log',
-                             '__contrail_log_local__': '--log-local',
+            template_vals = {
                              '__contrail_discovery_ip__' : cfgm_ip,
                              '__contrail_host_ip__' : self_collector_ip,
-                             '__contrail_listen_port__' : '8086',
-                             '__contrail_http_server_port__' : '8089',
                              '__contrail_cassandra_server_list__' : ' '.join('%s:%s' % cassandra_server for cassandra_server in cassandra_server_list),
                              '__contrail_analytics_data_ttl__' : self._args.analytics_data_ttl,
                              '__contrail_analytics_syslog_port__' : str(self._args.analytics_syslog_port)}
             self._template_substitute_write(vizd_param_template.template,
-                                           template_vals, temp_dir_name + '/vizd_param')
-            local("sudo mv %s/vizd_param /etc/contrail/vizd_param" %(temp_dir_name))
+                                           template_vals, temp_dir_name + '/collector.conf')
+            local("sudo mv %s/collector.conf /etc/contrail/collector.conf" %(temp_dir_name))
 
-            template_vals = {'__contrail_log_file__' : '/var/log/contrail/qe.log',
-                             '__contrail_log_local__': '--log-local',
-                             '__contrail_redis_server__': '127.0.0.1',
-                             '__contrail_redis_server_port__' : '6380',
-                             '__contrail_http_server_port__' : '8091',
-                             '__contrail_collector__' : '127.0.0.1',
-                             '__contrail_collector_port__' : '8086',
+            template_vals = {
                              '__contrail_cassandra_server_list__' : ' '.join('%s:%s' % cassandra_server for cassandra_server in cassandra_server_list)}
             self._template_substitute_write(qe_param_template.template,
-                                            template_vals, temp_dir_name + '/qe_param')
-            local("sudo mv %s/qe_param /etc/contrail/qe_param" %(temp_dir_name))
+                                            template_vals, temp_dir_name + '/query-engine.conf')
+            local("sudo mv %s/query-engine.conf /etc/contrail/query-engine.conf" %(temp_dir_name))
            
             template_vals = {'__contrail_log_file__' : '/var/log/contrail/opserver.log',
                              '__contrail_log_local__': '--log_local',
@@ -1086,18 +1077,15 @@ HWADDR=%s
             template_vals = {'__contrail_ifmap_usr__': '%s' %(control_ip),
                              '__contrail_ifmap_paswd__': '%s' %(control_ip),
                              '__contrail_collector__': collector_ip,
-                             '__contrail_collector_port__': '8086',
                              '__contrail_discovery_ip__': cfgm_ip,
                              '__contrail_hostname__': hostname,
                              '__contrail_host_ip__': control_ip,
-                             '__contrail_bgp_port__': '179',
                              '__contrail_cert_ops__': '"--use-certs=%s"' %(certdir) if use_certs else '',
-                             '__contrail_log_local__': '',
-                             '__contrail_logfile__': '--log-file=/var/log/contrail/control.log',
                             }
             self._template_substitute_write(bgp_param_template.template,
-                                            template_vals, temp_dir_name + '/control_param')
-            local("sudo mv %s/control_param /etc/contrail/control_param" %(temp_dir_name))
+                                            template_vals,
+                                            temp_dir_name + '/control-node.conf')
+            local("sudo mv %s/control-node.conf /etc/contrail/control-node.conf" %(temp_dir_name))
 
             dns_template_vals = {'__contrail_ifmap_usr__': '%s.dns' %(control_ip),
                              '__contrail_ifmap_paswd__': '%s.dns' %(control_ip),
@@ -1106,12 +1094,11 @@ HWADDR=%s
                              '__contrail_discovery_ip__': cfgm_ip,
                              '__contrail_host_ip__': control_ip,
                              '__contrail_cert_ops__': '"--use-certs=%s"' %(certdir) if use_certs else '',
-                             '__contrail_log_local__': '',
-                             '__contrail_logfile__': '--log-file=/var/log/contrail/dns.log',
                             }
             self._template_substitute_write(dns_param_template.template,
-                                            dns_template_vals, temp_dir_name + '/dns_param')
-            local("sudo mv %s/dns_param /etc/contrail/dns_param" %(temp_dir_name))
+                                            dns_template_vals,
+                                            temp_dir_name + '/dns.conf')
+            local("sudo mv %s/dns.conf /etc/contrail/dns.conf" %(temp_dir_name))
 
             with settings(host_string = 'root@%s' %(cfgm_ip), password = env.password):
                 if self._args.puppet_server:

--- a/templates/bgp_param_template.py
+++ b/templates/bgp_param_template.py
@@ -1,15 +1,41 @@
 import string
 
-template = string.Template("""
-IFMAP_USER=$__contrail_ifmap_usr__
-IFMAP_PASWD=$__contrail_ifmap_paswd__
-COLLECTOR=$__contrail_collector__
-COLLECTOR_PORT=$__contrail_collector_port__
-DISCOVERY=$__contrail_discovery_ip__
-HOSTNAME=$__contrail_hostname__
-HOSTIP=$__contrail_host_ip__
-BGP_PORT=$__contrail_bgp_port__
-CERT_OPTS=$__contrail_cert_ops__
-LOGFILE=$__contrail_logfile__
-LOG_LOCAL=$__contrail_log_local__
+template = string.Template("""#
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# Control-node configuration options
+#
+
+[DEFAULTS]
+hostip=$__contrail_host_ip__ # Resolved IP of `hostname`
+hostname=$__contrail_hostname__ # Retrieved as `hostname`
+http-server-port=8083
+test-mode=0
+xmpp-server-port=5269
+
+[BGP]
+config-file=bgp_config.xml
+port=179
+
+[COLLECTOR]
+port=8086
+server= # Provided by discovery server
+
+[DISCOVERY]
+port=5998
+server=$__contrail_discovery_ip__ # discovery-server IP address
+
+[IFMAP]
+certs-store=$__contrail_cert_ops__
+password=$__contrail_ifmap_paswd__
+server-url=
+user=$__contrail_ifmap_usr__
+
+[LOG]
+category=
+disable=0
+file=/var/log/contrail/control-node.log
+level=SYS_NOTICE
+local=0
+
 """)

--- a/templates/collector.conf.sh
+++ b/templates/collector.conf.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE="/etc/contrail/collector.conf"
+SIGNATURE="Collectror configuration options, generated from vizd_param"
+
+# Remove old style command line arguments from .ini file.
+perl -ni -e 's/command=.*/command=\/usr\/bin\/vizd/g; print $_;' /etc/contrail/supervisord_analytics_files/contrail-collector.ini
+
+if [ ! -e /etc/contrail/vizd_param ]; then
+    exit
+fi
+
+# Ignore if the converted file is already generated once before
+if [ -e $CONFIG_FILE ]; then
+    grep --quiet "$SIGNATURE" $CONFIG_FILE > /dev/null
+
+    # Exit if configuraiton already converted!
+    if [ $? == 0 ]; then
+        exit
+    fi
+fi
+
+source /etc/contrail/vizd_param
+
+(
+cat << EOF
+#
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# $SIGNATURE
+#
+
+[DEFAULTS]
+analytics-data-ttl=0
+cassandra-server=$CASSANDRA_SERVER_LIST
+dup=0
+hostip=$HOST_IP # Retrieved as IPv4 address of `hostname`
+http-server-port=$HTTP_SERVER_PORT
+listen-port=$LISTEN_PORT
+
+[DISCOVERY]
+port=5998
+server=$DISCOVERY # discovery-server IP address
+
+[REDIS]
+ip=127.0.0.1
+port=6381
+
+[LOG]
+category=
+file=$LOG_FILE
+level=SYS_DEBUG
+local=1
+listen-port=$ANALYTICS_SYSLOG_PORT
+
+EOF
+) > $CONFIG_FILE

--- a/templates/control-node.conf.sh
+++ b/templates/control-node.conf.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE="/etc/contrail/control-node.conf"
+SIGNATURE="Control-node configuration options, generated from control_param"
+
+# Remove old style command line arguments from .ini file.
+perl -ni -e 's/command=.*/command=\/usr\/bin\/control-node/g; print $_;' /etc/contrail/supervisord_control_files/contrail-control.ini
+
+if [ ! -e /etc/contrail/control_param ]; then
+    exit
+fi
+
+# Ignore if the converted file is already generated once before
+if [ -e $CONFIG_FILE ]; then
+    grep --quiet "$SIGNATURE" $CONFIG_FILE > /dev/null
+
+    # Exit if configuraiton already converted!
+    if [ $? == 0 ]; then
+        exit
+    fi
+fi
+
+source /etc/contrail/control_param
+
+(
+cat << EOF
+#
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# $SIGNATURE
+#
+
+[DEFAULTS]
+hostip=$HOSTIP # Resolved IP of `hostname`
+hostname=$HOSTNAME # Retrieved as `hostname`
+http-server-port=8083
+test-mode=0
+xmpp-server-port=5269
+
+[BGP]
+config-file=bgp_config.xml
+port=$BGP_PORT
+
+[COLLECTOR]
+port=8086
+server= # Provided by discovery server
+
+[DISCOVERY]
+port=5998
+server=$DISCOVERY # discovery-server IP address
+
+[IFMAP]
+certs-store=$CERT_OPTS
+password=$IFMAP_PASWD
+server-url= # Provided by discovery server, e.g. https://127.0.0.1:8443
+user=$IFMAP_USER
+
+[LOG]
+category=
+disable=0
+file=/var/log/contrail/control-node.log
+level=SYS_NOTICE
+local=0
+
+EOF
+) > $CONFIG_FILE

--- a/templates/dns.conf.sh
+++ b/templates/dns.conf.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE="/etc/contrail/dns.conf"
+SIGNATURE="Dns configuration options, generated from dns_param"
+
+# Remove old style command line arguments from .ini file.
+perl -ni -e 's/command=.*/command=\/usr\/bin\/dnsd/g; print $_;' /etc/contrail/supervisord_control_files/contrail-dns.ini
+
+if [ ! -e /etc/contrail/dns_param ]; then
+    exit
+fi
+
+# Ignore if the converted file is already generated once before
+if [ -e $CONFIG_FILE ]; then
+    grep --quiet "$SIGNATURE" $CONFIG_FILE > /dev/null
+
+    # Exit if configuraiton already converted!
+    if [ $? == 0 ]; then
+        exit
+    fi
+fi
+
+source /etc/contrail/dns_param
+
+(
+cat << EOF
+#
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# $SIGNATURE
+#
+
+[DEFAULTS]
+dns-config-file=dns_config.xml
+hostip=$HOSTIP # Resolved IP of `hostname`
+http-server-port=8092
+
+[COLLECTOR]
+port=8086
+server= # Provided by discovery server
+
+[DISCOVERY]
+port=5998
+server=$DISCOVERY # discovery-server IP address
+
+[IFMAP]
+password=$IFMAP_PASWD
+server-url=https://$IFMAP_SERVER:$IFMAP_PORT
+user=$IFMAP_USER
+certs-store=$CERT_OPTS
+
+[LOG]
+category=
+disable=0
+file=/var/log/contrail/dns.log
+level=SYS_NOTICE
+local=0
+
+EOF
+) > $CONFIG_FILE

--- a/templates/dns_param_template.py
+++ b/templates/dns_param_template.py
@@ -1,13 +1,34 @@
 import string
 
 template = string.Template("""
-IFMAP_USER=$__contrail_ifmap_usr__
-IFMAP_PASWD=$__contrail_ifmap_paswd__
-COLLECTOR=$__contrail_collector__
-COLLECTOR_PORT=$__contrail_collector_port__
-DISCOVERY=$__contrail_discovery_ip__
-HOSTIP=$__contrail_host_ip__
-CERT_OPTS=$__contrail_cert_ops__
-LOGFILE=$__contrail_logfile__
-LOG_LOCAL=$__contrail_log_local__
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# Dns configuration options
+#
+
+[DEFAULTS]
+dns-config-file=dns_config.xml
+hostip=$__contrail_host_ip__ # Resolved IP of `hostname`
+http-server-port=8092
+
+[COLLECTOR]
+port=8086
+server= # Provided by discovery server
+
+[DISCOVERY]
+port=5998
+server=$__contrail_discovery_ip__ # discovery-server IP address
+
+[LOG]
+category=
+disable=0
+file=/var/log/contrail/dns.log
+level=SYS_NOTICE
+local=0
+
+[IFMAP]
+certs-store=$__contrail_cert_ops__
+password=$__contrail_ifmap_paswd__
+user=$__contrail_ifmap_usr__
+
 """)

--- a/templates/qe_param_template.py
+++ b/templates/qe_param_template.py
@@ -1,12 +1,28 @@
 import string
 
-template = string.Template("""
-CASSANDRA_SERVER_LIST=$__contrail_cassandra_server_list__
-REDIS_SERVER=$__contrail_redis_server__
-REDIS_SERVER_PORT=$__contrail_redis_server_port__
-HTTP_SERVER_PORT=$__contrail_http_server_port__
-LOG_FILE=$__contrail_log_file__
-LOG_LOCAL=$__contrail_log_local__
-COLLECTOR=$__contrail_collector__
-COLLECTOR_PORT=$__contrail_collector_port__
+template = string.Template("""#
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# Query-engine daemon configuration options
+#
+
+[DEFAULTS]
+analytics-data-ttl=0
+cassandra-server=$__contrail_cassandra_server_list__
+collector-server= # Provided by discovery server
+http-server-port=8091
+
+[DISCOVERY]
+port=5998
+server= # discovery-server IP address
+
+[LOG]
+category=
+file=/var/log/contrail/qe.log
+level=SYS_DEBUG
+local=1
+
+[REDIS]
+ip=127.0.0.1
+port=6380
 """)

--- a/templates/query-engine.conf.sh
+++ b/templates/query-engine.conf.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE="/etc/contrail/query-engine.conf"
+SIGNATURE="Query Engine configuration options, generated from qe_param"
+
+# Remove old style command line arguments from .ini file.
+perl -ni -e 's/command=.*/command=\/usr\/bin\/qed/g; print $_;' /etc/contrail/supervisord_analytics_files/contrail-qe.ini
+
+if [ ! -e /etc/contrail/qe_param ]; then
+    exit
+fi
+
+# Ignore if the converted file is already generated once before
+if [ -e $CONFIG_FILE ]; then
+    grep --quiet "$SIGNATURE" $CONFIG_FILE > /dev/null
+
+    # Exit if configuraiton already converted!
+    if [ $? == 0 ]; then
+        exit
+    fi
+fi
+
+source /etc/contrail/qe_param
+
+(
+cat << EOF
+#
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# $SIGNATURE
+#
+
+[DEFAULTS]
+analytics-data-ttl=0
+cassandra-server=$CASSANDRA_SERVER_LIST
+collector-server= # Provided by discovery server
+http-server-port=8091
+max-slice=100
+max-tasks=16
+start-time=0
+
+[DISCOVERY]
+port=5998
+server= # discovery-server IP address
+
+[LOG]
+category=
+file=/var/log/contrail/qe.log
+level=SYS_DEBUG
+local=1
+
+[REDIS]
+ip=127.0.0.1
+port=6380
+
+EOF
+) > $CONFIG_FILE

--- a/templates/vizd_param_template.py
+++ b/templates/vizd_param_template.py
@@ -1,15 +1,31 @@
 import string
 
 template = string.Template("""
-CASSANDRA_SERVER_LIST=$__contrail_cassandra_server_list__
-REDIS_SERVER=$__contrail_redis_server__
-REDIS_SERVER_PORT=$__contrail_redis_server_port__
-DISCOVERY=$__contrail_discovery_ip__
-HOST_IP=$__contrail_host_ip__
-LISTEN_PORT=$__contrail_listen_port__
-HTTP_SERVER_PORT=$__contrail_http_server_port__
-LOG_FILE=$__contrail_log_file__
-LOG_LOCAL=$__contrail_log_local__
-ANALYTICS_DATA_TTL=$__contrail_analytics_data_ttl__
-ANALYTICS_SYSLOG_PORT=$__contrail_analytics_syslog_port__
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# Collector configuration options
+#
+
+[DEFAULTS]
+analytics-data-ttl=$__contrail_analytics_data_ttl__
+cassandra-server=$__contrail_cassandra_server_list__
+dup=0
+hostip=$__contrail_host_ip__ # Retrieved as IPv4 address of `hostname`
+http-server-port=8089
+listen-port=8086
+
+[DISCOVERY]
+port=5998
+server=$__contrail_discovery_ip__ # discovery-server IP address
+
+[REDIS]
+ip=127.0.0.1
+port=6381
+
+[LOG]
+category=
+file=/var/log/contrail/collector.log
+level=SYS_DEBUG
+local=1
+listen-port=$__contrail_analytics_syslog_port__
 """)

--- a/templates/vrouter.conf.sh
+++ b/templates/vrouter.conf.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE="/etc/contrail/vrouter.conf"
+SIGNATURE="Vrouter configuration options, generated from agent_param"
+
+# Remove old style command line arguments from .ini file.
+perl -ni -e 's/command=.*/command=\/usr\/bin\/vnswad/g; print $_;' /etc/contrail/supervisord_vrouter_files/contrail-vrouter.ini
+
+if [ ! -e /etc/contrail/agent_param ]; then
+    exit
+fi
+
+# Ignore if the converted file is already generated once before
+if [ -e $CONFIG_FILE ]; then
+    grep --quiet "$SIGNATURE" $CONFIG_FILE > /dev/null
+
+    # Exit if configuraiton already converted!
+    if [ $? == 0 ]; then
+
+        exit
+    fi
+fi
+
+source /etc/contrail/agent_param
+
+# if [ -e /etc/contrail/agent.conf ]; then
+#
+#     # Convert /etc/contrail/agent.conf xml file to param file and source it.
+#     python /etc/contrail/vrouter_xml_to_param.py > /etc/contrail/vrouter_param
+#     source /etc/contrail/vrouter_param
+# fi
+
+(
+cat << EOF
+#
+# Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+#
+# $SIGNATURE
+#
+
+[DEFAULTS]
+hostname= # Retrieved as `hostname`
+http-server-port=8085
+config-file=/etc/contrail/agent.conf
+
+[COLLECTOR]
+port=8086
+server= # Provided by discovery server
+
+[HYPERVISOR]
+type=kvm
+xen-ll-ip-address=
+xen-ll-prefix-len=0
+xen-ll-port=
+vmware-physical-port=
+
+[LOG]
+category=
+file=/var/log/contrail/vrouter.log
+level=SYS_DEBUG
+local=0
+
+[KERNEL]
+disable-vhost=0
+disable-ksync=0
+disable-services=0
+disable-packet=0
+
+EOF
+) > $CONFIG_FILE


### PR DESCRIPTION
o control-node
o collector (vizd)
o dns
o query-engine
o vnswad (vrouter)

These daemons now take configuration in the standard .ini format.
Default configuration file is read off

/etc/contrail/control-node.conf
/etc/contrail/collector.conf
/etc/contrail/dns.conf
/etc/contrail/query-engine.conf
/etc/contrail/vrouter.conf

One can override the values from the config file through command line option
as well. e.g. --LOG.level=DEBUG, --DEFAULTS.hostip=1.2.3.4, etc.

Use --help to see various options available. Package also places the default
config file under /etc/contrail/.

When configuration changes are made, the process must be _restarted_ to
take effect.
