### PR TITLE
connect to zookeeper cluster instead of connecting only to local server

### DIFF
--- a/contrail_setup_utils/setup.py
+++ b/contrail_setup_utils/setup.py
@@ -922,14 +922,8 @@ HWADDR=%s
             keystone_ip = self._args.keystone_ip
             region_name = self._args.region_name
             cassandra_server_list = [(cassandra_server_ip, '9160') for cassandra_server_ip in self._args.cassandra_ip_list]
-            if cfgm_ip in self._args.zookeeper_ip_list:
-                # prefer local zk if available
-                zk_servers = '%s' %(cfgm_ip)
-                zk_servers_ports = '%s:2181' %(cfgm_ip)
-            else:
-                zk_servers = ','.join(self._args.zookeeper_ip_list)
-                zk_servers_ports = \
-                ','.join(['%s:2181' %(s) for s in self._args.zookeeper_ip_list])
+            zk_servers = ','.join(self._args.zookeeper_ip_list)
+            zk_servers_ports = ','.join(['%s:2181' %(s) for s in self._args.zookeeper_ip_list])
 
             # api_server.conf
             template_vals = {'__contrail_ifmap_server_ip__': cfgm_ip,


### PR DESCRIPTION
Sanity Result: http://10.204.216.50/Docs/logs/0000_2014_04_20_12_27_13/test_report.html
1. Track the zookeeper state
2. Exit if the connection is LOST and
3. Pause the master if connection moves to SUSPENDED. (Since master could have switched)
    A. Changed schema and svc mon to wait in main loop.
    B. Discovery change is pending. To be handled in
    C. API server doesn’t accept any request (PUT, POST and DELETE) if not connected to Zookeeper. Only accept GET request. In this case we don’t query zookeeper.
4. Connect to all zookeeper server instead of connecting to local zookeeper server.(Pass list of server while creating KazooClient)
5. Change the retry logic with KazooRetry. Kazoo client has logic to reconnect automatically till SessionExpires(LOST). Instead of reconnecting from our application logic, use KazooRetry to retry zookeeper operation.
