### PR TITLE
brute force fix to flush the file and sleep for couple of seconds to overcome possible timing issue

### DIFF
--- a/setup-vnc-interfaces.py
+++ b/setup-vnc-interfaces.py
@@ -114,6 +114,7 @@ class BaseInterface(object):
             fd.write('\n'.join(['%s=%s' %(key, value) \
                           for key, value in cfg.items()]))
             fd.write('\n')
+            fd.flush()
         os.system('sudo cp -f %s %s'%(self.tempfile.name, nwfile))
 
     def get_mac_addr(self, iface):
@@ -183,7 +184,8 @@ class BaseInterface(object):
                'BOOTPROTO'     : 'none',
                'NM_CONTROLLED' : 'no',
                'BONDING_MASTER': 'yes',
-               'BONDING_OPTS'  : "\"%s\""%self.bond_opts_str.strip()
+               'BONDING_OPTS'  : "\"%s\""%self.bond_opts_str.strip(),
+               'SUBCHANNELS'   : '1,2,3'
               }
         if not self.vlan:
             cfg.update({'NETMASK'       : self.netmask,
@@ -244,6 +246,7 @@ class BaseInterface(object):
             self.create_bonding_interface()
         else:
             self.create_interface()
+        time.sleep(3)
         self.post_conf()
 
 class UbuntuInterface(BaseInterface):
@@ -318,6 +321,7 @@ class UbuntuInterface(BaseInterface):
             fd.write('\n%s\n' %cfg[0])
             fd.write('\n    '.join(cfg[1:]))
             fd.write('\n')
+            fd.flush()
         os.system('sudo cp -f %s %s'%(self.tempfile.name, interface_file))
 
     def create_interface(self):


### PR DESCRIPTION
Also adding subchannels to bonded interface since NM takes over if we dont specify a mac addr or subchannel.
May  9 01:08:59 nodec61 NetworkManager[1349]:    ifcfg-rh:     warning: NM_CONTROLLED was false but HWADDR or SUBCHANNELS was missing; device will be managed
